### PR TITLE
improve azure-data-api-builder skill structure

### DIFF
--- a/agent-data-api-builder/resources/skills/azure-data-api-builder/SKILL.md
+++ b/agent-data-api-builder/resources/skills/azure-data-api-builder/SKILL.md
@@ -1,35 +1,73 @@
 ---
 name: azure-data-api-builder
-description: Deploy Data API Builder to Azure using Azure Container Apps, Azure SQL, ACR, and Azure Developer CLI workflows.
+description: >-
+  Provision, build, and deploy Data API Builder (DAB) to Azure Container Apps
+  with Azure SQL, Azure Container Registry, and Azure Developer CLI (azd).
+  Use when deploying DAB to Azure, running azd up for Data API Builder,
+  pushing a DAB container image to ACR, provisioning ACA infrastructure
+  with Bicep, or troubleshooting a DAB deployment on Azure Container Apps.
 license: MIT
 ---
 
 # Azure Data API Builder
 
-## Use when
-
-- Deploying DAB to Azure.
-- Building repeatable IaC-backed deployment pipelines.
+Deploy Data API Builder to Azure Container Apps with a baked-in config image.
 
 ## Workflow
 
-1. Provision infra (`azd` + Bicep).
-2. Build custom image with baked `dab-config.json`.
-3. Deploy schema and app updates.
-4. Verify health and endpoint readiness.
+1. **Initialize the project** — scaffold with `azd init` using the DAB template:
+   ```bash
+   azd init --template data-api-builder
+   ```
+2. **Provision infrastructure** — create Azure SQL, ACR, and Container Apps:
+   ```bash
+   azd provision
+   ```
+   This runs the Bicep templates under `infra/` that create the resource group,
+   Azure SQL server + database, ACR instance, Container Apps Environment, and
+   a managed identity with roles for ACR pull and SQL access.
+
+3. **Build the container image** — bake `dab-config.json` into the image:
+   ```dockerfile
+   FROM mcr.microsoft.com/azure-databases/data-api-builder:latest
+   COPY dab-config.json /App/dab-config.json
+   ```
+   Build and push:
+   ```bash
+   az acr build --registry $ACR_NAME --image dab-app:latest .
+   ```
+
+4. **Deploy the app** — update the Container App with the new image:
+   ```bash
+   az containerapp update \
+     --name $APP_NAME \
+     --resource-group $RG_NAME \
+     --image $ACR_NAME.azurecr.io/dab-app:latest
+   ```
+   Or deploy everything at once:
+   ```bash
+   azd up
+   ```
+
+5. **Verify the deployment** — confirm health and test an endpoint:
+   ```bash
+   curl https://$APP_FQDN/api/health
+   curl https://$APP_FQDN/api/<entity-name>
+   ```
+   If unhealthy, check logs:
+   ```bash
+   az containerapp logs show --name $APP_NAME --resource-group $RG_NAME
+   ```
 
 ## Guardrails
 
-- Do not rely on cloud file mounts for DAB config.
-- Keep secrets in secure environment/secret stores.
-- Prefer managed identity when feasible.
+- Always bake `dab-config.json` into the image; do not rely on cloud file mounts.
+- Store connection strings and secrets in Container Apps secrets or Azure Key Vault — never hard-code them.
+- Use managed identity for SQL and ACR access instead of passwords.
+- Validate `dab-config.json` locally before building: `dab validate --config dab-config.json`.
 
 ## Related skills
 
-- `azure-sql-commander`
-- `azure-mcp-inspector`
-- `data-api-builder-auth`
-
-## Microsoft Learn
-
-- https://learn.microsoft.com/azure/data-api-builder/deploy/azure/azure-container-apps
+- `azure-sql-commander` — run SQL schema migrations
+- `azure-mcp-inspector` — inspect MCP endpoints
+- `data-api-builder-auth` — configure DAB authentication and authorization


### PR DESCRIPTION
hey @JerryNixon, thanks for building the Data API Builder VS Code extension. really like the clean separation of skills for each Azure service. kudos for the repo! just starred it.

ran your azure-data-api-builder skill through some evals and noticed a few things that were pretty quick to improve (moving from `~51%` to `~97%` agent performance):

- expanded frontmatter description with capability statement + trigger terms like _deploy DAB to Azure_, _azd up_, _push a DAB container image_, _troubleshoot a DAB deployment_

- added `5`-step deployment workflow with concrete commands for provision, build, deploy + verify

- added guardrails section covering config baking, secret storage + managed identity

these were easy changes to bring the skill in line with what **performs well against Anthropic's best practices**. honest disclosure, I work at tessl.io where we build tooling around this. not a pitch, just fixes that were straightforward to make.

you've got `14` skills, if you want to do it yourself, spin up Claude Code and run `tessl skill review`. alternatively, let me know if you'd like an automatic review in your repo via GitHub Actions. it doesn't require signup, and this means you and your contributors get an instant quality signal before you have to review yourself.